### PR TITLE
Add references

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+DocumenterCitations = "daee34ce-89f3-4625-b898-19384cb65244"
 GLMakie = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a"
 Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,6 +1,7 @@
-using SpinDoctor
-using Literate
 using Documenter
+using DocumenterCitations
+using Literate
+using SpinDoctor
 
 DocMeta.setdocmeta!(SpinDoctor, :DocTestSetup, :(using SpinDoctor); recursive = true)
 
@@ -21,7 +22,10 @@ for e ∈ examples
     # Literate.script(e, o)
 end
 
-makedocs(;
+bib = CitationBibliography(joinpath(@__DIR__, "references.bib"))
+
+makedocs(
+    bib;
     modules = [SpinDoctor],
     authors = "Syver Døving Agdestein and contributors",
     repo = "https://github.com/SpinDoctorMRI/SpinDoctor.jl/blob/{commit}{path}#{line}",
@@ -44,6 +48,7 @@ makedocs(;
         ],
         "Neurons" => "neurons.md",
         "API Reference" => "api.md",
+        "References" => "references.md",
     ],
 )
 

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -1,0 +1,297 @@
+
+@article{Agdestein2021,
+  author   = {Agdestein, Syver Døving and Tran, Try Nguyen and Li, Jing-Rebecca},
+  doi      = {https://doi.org/10.1002/nbm.4646},
+  eprint   = {https://analyticalsciencejournals.onlinelibrary.wiley.com/doi/pdf/10.1002/nbm.4646},
+  journal  = {NMR in Biomedicine},
+  keywords = {Bloch-Torrey equation, diffusion MRI, finite elements, Laplace eigenfunctions, matrix formalism, permeability, simulation},
+  month    = {11},
+  pages    = {e4646},
+  title    = {Practical computation of the diffusion MRI signal based on Laplace eigenfunctions: permeable interfaces},
+  url      = {https://analyticalsciencejournals.onlinelibrary.wiley.com/doi/abs/10.1002/nbm.4646},
+  year     = {2022}
+}
+
+@article{Ascoli2007,
+  author    = {Ascoli, Giorgio A. and Donohue, Duncan E. and Halavi, Maryam},
+  doi       = {10.1523/JNEUROSCI.2055-07.2007},
+  eprint    = {http://www.jneurosci.org/content/27/35/9247.full.pdf},
+  issn      = {0270-6474},
+  journal   = {Journal of Neuroscience},
+  number    = {35},
+  pages     = {9247--9251},
+  publisher = {Society for Neuroscience},
+  title     = {NeuroMorpho.Org: A Central Resource for Neuronal Morphologies},
+  url       = {http://www.jneurosci.org/content/27/35/9247},
+  volume    = {27},
+  year      = {2007}
+}
+
+@article{Barzykin1999,
+  author    = {Barzykin, Alexandre V},
+  journal   = {Journal of Magnetic Resonance},
+  number    = {2},
+  pages     = {342--353},
+  publisher = {Elsevier},
+  timestamp = {2013.10.09},
+  title     = {Theory of spin echo in restricted geometries under a step-wise gradient pulse sequence},
+  url       = {http://www.sciencedirect.com/science/article/pii/S1090780799917780},
+  volume    = {139},
+  year      = {1999}
+}
+
+@article{Callaghan1995,
+  author    = {Callaghan, Paul T. and Stepianik, Janez},
+  issn      = {1064-1858},
+  journal   = {Journal of Magnetic Resonance, Series A},
+  month     = nov,
+  number    = {1},
+  pages     = {118--122},
+  timestamp = {2013.12.05},
+  title     = {Frequency-Domain Analysis of Spin Motion Using Modulated-Gradient {NMR}},
+  url       = {http://www.sciencedirect.com/science/article/pii/S1064185885799597},
+  volume    = {117},
+  year      = {1995}
+}
+
+@article{Callaghan1997,
+  author    = {Callaghan, Paul},
+  groups    = {NMR},
+  journal   = {Journal of Magnetic Resonance},
+  month     = nov,
+  number    = {1},
+  pages     = {74--84},
+  refid     = {citeulike:3169788},
+  timestamp = {2010.02.16},
+  title     = {A Simple Matrix Formalism for Spin Echo Analysis of Restricted Diffusion under Generalized Gradient Waveforms},
+  url       = {http://dx.doi.org/10.1006/jmre.1997.1233},
+  volume    = {129},
+  year      = {1997}
+}
+
+@article{Does2003,
+  author    = {Does, Mark D. and Parsons, Edward C. and Gore, John C.},
+  doi       = {10.1002/mrm.10385},
+  issn      = {1522-2594},
+  journal   = {Magn. Reson. Med.},
+  keywords  = {MRI, diffusion, restriction, ischemia, oscillating gradient},
+  number    = {2},
+  pages     = {206--215},
+  publisher = {Wiley Subscription Services, Inc., A Wiley Company},
+  timestamp = {2013.01.21},
+  title     = {Oscillating gradient measurements of water diffusion in normal and globally ischemic rat brain},
+  volume    = {49},
+  year      = {2003}
+}
+
+@article{Fang2020,
+  author   = {Chengran Fang and Van-Dang Nguyen and Demian Wassermann and Jing-Rebecca Li},
+  doi      = {https://doi.org/10.1016/j.neuroimage.2020.117198},
+  issn     = {1053-8119},
+  journal  = {NeuroImage},
+  keywords = {Bloch-Torrey equation, Diffusion magnetic resonance imaging, Finite elements, Monte-Carlo, Simulation, Neurons},
+  pages    = {117198},
+  title    = {Diffusion {MRI} simulation of realistic neurons with {SpinDoctor} and the {Neuron Module}},
+  url      = {http://www.sciencedirect.com/science/article/pii/S1053811920306844},
+  volume   = {222},
+  year     = {2020}
+}
+
+@article{Grebenkov2007,
+  author    = {Grebenkov, Denis},
+  doi       = {10.1103/RevModPhys.79.1077},
+  groups    = {NMR},
+  journal   = {Reviews of Modern Physics},
+  number    = {3},
+  pages     = {1077--1137},
+  publisher = {American Physical Society},
+  refid     = {citeulike:1684021},
+  timestamp = {2010.02.16},
+  title     = {{NMR} survey of reflected Brownian motion},
+  volume    = {79},
+  year      = {2007}
+}
+
+@article{Grebenkov2010a,
+  author    = {Grebenkov, Denis S.},
+  issn      = {1090-7807},
+  journal   = {Journal of Magnetic Resonance},
+  keywords  = {Restricted diffusion, PGSE, Eigenfunction, Matrix formalism, Permeability},
+  month     = aug,
+  number    = {2},
+  pages     = {181--195},
+  timestamp = {2012.11.22},
+  title     = {Pulsed-gradient spin-echo monitoring of restricted diffusion in multilayered structures},
+  url       = {http://www.sciencedirect.com/science/article/pii/S1090780710001199},
+  volume    = {205},
+  year      = {2010}
+}
+
+@article{Lee2021,
+  author   = {Hong-Hsi Lee and Els Fieremans and Dmitry S. Novikov},
+  doi      = {https://doi.org/10.1016/j.jneumeth.2020.109018},
+  issn     = {0165-0270},
+  journal  = {Journal of Neuroscience Methods},
+  keywords = {Monte Carlo simulation, Realistic microstructure, Numerical validation, Diffusion MR, Biophysical modeling},
+  pages    = {109018},
+  title    = {Realistic Microstructure Simulator (RMS): Monte Carlo simulations of diffusion in three-dimensional cell segmentations of microscopy images},
+  url      = {https://www.sciencedirect.com/science/article/pii/S0165027020304416},
+  volume   = {350},
+  year     = {2021}
+}
+
+@article{Li2019,
+  author  = {Jing-Rebecca Li and Van-Dang Nguyen and Try Nguyen Tran and Jan Valdman and Cong-Bang Trang and Khieu Van Nguyen and Duc Thach Son Vu and Hoang An Tran and Hoang Trong An Tran and Thi Minh Phuong Nguyen},
+  doi     = {https://doi.org/10.1016/j.neuroimage.2019.116120},
+  issn    = {1053-8119},
+  journal = {NeuroImage},
+  pages   = {116120},
+  title   = {{SpinDoctor: A MATLAB toolbox for diffusion MRI simulation}},
+  url     = {http://www.sciencedirect.com/science/article/pii/S1053811919307116},
+  volume  = {202},
+  year    = {2019}
+}
+
+@article{Li2020,
+  author  = {Li, Jing-Rebecca and Tran, Try and Nguyen, Van-Dang},
+  doi     = {10.1002/nbm.4353},
+  journal = {NMR in Biomedicine},
+  month   = {07},
+  pages   = {},
+  title   = {Practical computation of the diffusion {MRI} signal of realistic neurons based on {Laplace} eigenfunctions},
+  volume  = {33},
+  year    = {2020}
+}
+
+@article{Mitra1992,
+  author    = {Mitra, Partha P and Sen, Pabitra N and Schwartz, Lawrence M and Le Doussal, Pierre},
+  journal   = {Physical review letters},
+  number    = {24},
+  pages     = {3555--3558},
+  timestamp = {2013.10.09},
+  title     = {Diffusion propagator as a probe of the structure of porous media},
+  volume    = {68},
+  year      = {1992}
+}
+
+@article{Mitra1993,
+  author    = {Mitra, Partha P. and Sen, Pabitra N. and Schwartz, Lawrence M.},
+  issue     = {14},
+  journal   = {Phys. Rev. B},
+  month     = {Apr},
+  numpages  = {0},
+  pages     = {8565--8574},
+  publisher = {American Physical Society},
+  timestamp = {2016.09.26},
+  title     = {Short-time behavior of the diffusion coefficient as a geometrical probe of porous media},
+  volume    = {47},
+  year      = {1993}
+}
+
+@article{Nguyen2014d,
+  author   = {Dang Van Nguyen and Jing-Rebecca Li and Denis Grebenkov and Denis Le Bihan},
+  doi      = {10.1016/j.jcp.2014.01.009},
+  issn     = {0021-9991},
+  journal  = {Journal of Computational Physics},
+  keywords = {Bloch–Torrey equation, Diffusion magnetic resonance imaging, Finite elements, \{RKC\}, Pseudo-periodic, Double-node, Interface problem},
+  number   = {0},
+  pages    = {283 - 302},
+  title    = {A finite elements method to solve the Bloch–Torrey equation applied to diffusion magnetic resonance imaging},
+  url      = {http://www.sciencedirect.com/science/article/pii/S0021999114000308},
+  volume   = {263},
+  year     = {2014}
+}
+
+@article{Rahman2013,
+  author  = {Rahman, Talal and Valdman, Jan},
+  journal = {Applied Mathematics and Computation},
+  number  = {13},
+  pages   = {7151--7158},
+  title   = {Fast MATLAB assembly of FEM matrices in 2D and 3D: nodal elements},
+  volume  = {219},
+  year    = {2013}
+}
+
+@article{Schiavi2016,
+  author    = {Schiavi, Simona and Haddar, Houssem and Li, Jing-Rebecca},
+  journal   = {SIAM Journal on Applied Mathematics},
+  note      = {Accepted.},
+  timestamp = {2016.04.11},
+  title     = {A macroscopic model for the diffusion MRI signal accounting for time-dependent diffusivity},
+  year      = {2016}
+}
+
+@incollection{Shewchuk1996b,
+  author    = {Jonathan Richard Shewchuk},
+  booktitle = {Applied Computational Geometry:  Towards Geometric Engineering},
+  editor    = {Ming C. Lin and Dinesh Manocha},
+  month     = may,
+  note      = {From the First ACM Workshop on Applied Computational Geometry},
+  pages     = {203--222},
+  publisher = {Springer-Verlag},
+  series    = {Lecture Notes in Computer Science},
+  title     = {Triangle:  {E}ngineering a {2D} {Q}uality {M}esh {G}enerator and {D}elaunay {T}riangulator},
+  volume    = 1148,
+  year      = 1996
+}
+
+@article{Si2015,
+  acmid      = {2629697},
+  address    = {New York, NY, USA},
+  articleno  = {11},
+  author     = {Si, Hang},
+  doi        = {10.1145/2629697},
+  issn       = {0098-3500},
+  issue_date = {January 2015},
+  journal    = {ACM Trans. Math. Softw.},
+  keywords   = {Delaunay, Steiner points, Tetrahedral mesh generation, boundary recovery, constrained Delaunay, edge removal, flips, mesh improvement, mesh quality, mesh refinement},
+  month      = {02},
+  number     = {2},
+  numpages   = {36},
+  pages      = {11:1--11:36},
+  publisher  = {ACM},
+  title      = {TetGen, a Delaunay-Based Quality Tetrahedral Mesh Generator},
+  url        = {http://doi.acm.org/10.1145/2629697},
+  volume     = {41},
+  year       = {2015}
+}
+
+@article{Stejskal1965,
+  author    = {Stejskal, E. O. and Tanner, J. E.},
+  doi       = {10.1063/1.1695690},
+  groups    = {NMR},
+  journal   = {The Journal of Chemical Physics},
+  number    = {1},
+  pages     = {288--292},
+  publisher = {AIP},
+  timestamp = {2011.11.18},
+  title     = {Spin Diffusion Measurements: Spin Echoes in the Presence of a Time-Dependent Field Gradient},
+  volume    = {42},
+  year      = {1965}
+}
+
+@article{Watson2006,
+  author    = {Watson, Karli K and Jones, Todd K and Allman, John M},
+  journal   = {Neuroscience},
+  number    = {3},
+  pages     = {1107--1112},
+  publisher = {Elsevier},
+  title     = {Dendritic architecture of the von Economo neurons},
+  volume    = {141},
+  year      = {2006}
+}
+
+@article{Xu2007,
+  author    = {Xu, J and Does, MD and Gore, JC},
+  groups    = {NMR},
+  issn      = {0031-9155},
+  journal   = {Physics in medicine and biology},
+  month     = apr,
+  number    = {7},
+  refid     = {citeulike:4255763},
+  timestamp = {2010.02.16},
+  title     = {Numerical study of water diffusion in biological tissues using an improved finite difference method},
+  url       = {http://view.ncbi.nlm.nih.gov/pubmed/17374905},
+  volume    = {52},
+  year      = {2007}
+}

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -9,7 +9,7 @@ is based on the
 [SpinDoctor User Guide](https://github.com/jingrebeccali/SpinDoctor/blob/master/user_guide.pdf).
 
 SpinDoctor is a software package that performs numerical simulations of diffusion magnetic
-resonance imaging (dMRI) for prototyping purposes.
+resonance imaging (dMRI) for prototyping purposes [Li2019](@cite).
 
 SpinDoctor can be used
 
@@ -25,10 +25,10 @@ SpinDoctor can be used
 The PDEs and Laplace eigenvalue decompositions are solved by P1 finite elements. The
 geometry recipes create surface triangulations that are passed to
 [TetGen](https://wias-berlin.de/software/index.jsp?id=TetGen&lang=1) to perform the finite
-element mesh generation.
+element mesh generation (see [Si2015](@cite)).
 
 SpinDoctor has support for the following features:
-1. multiple compartments connected through permeable membranes, with different
+1. multiple compartments connected through permeable membranes [Nguyen2014d](@cite), with different
     * initial spin densities,
     * diffusion tensors,
     * T2-relaxation, and

--- a/docs/src/neurons.md
+++ b/docs/src/neurons.md
@@ -5,12 +5,14 @@ Bloch-Torrey partial differential equation. In order to facilitate the diffusion
 simulation of realistic neurons by the research community, we constructed finite element
 meshes for a group of 36 pyramidal neurons and a group of 29 spindle neurons whose
 morphological descriptions were found in the publicly available neuron repository
-[NeuroMopho.org](http://neuromorpho.org). These finite elements meshes range from having
+[NeuroMopho.org](http://neuromorpho.org) [Fang2020](@cite). These finite elements meshes range from having
 15163 nodes to 622553 nodes. We also broke the neurons into the soma and dendrite branches
 and created finite elements meshes for these cell components. Through the Neuron Module,
 these neuron and components finite element meshes can be seamlessly coupled with the
 functionalities of SpinDoctor to provide the diffusion MRI signal that can be attributed to
 spins inside neurons.
+
+The neuron models and the measurement data are from [Ascoli2007](@cite) and [Watson2006](@cite).
 
 The neuron mesh files are available at
 [https://github.com/SpinDoctorMRI/RealNeuronMeshes](https://github.com/SpinDoctorMRI/RealNeuronMeshes).
@@ -122,5 +124,3 @@ The following table shows the morphological characteristics for the neurons.
 | 28o\_spindle21aFI    | fronto-insula      | 2.62                  | 298.57             | 35579.06                | 37783.31                 |
 | 29o\_spindle22aFI    | fronto-insula      | 3.52                  | 402.84             | 62928.22                | 83279.12                 |
 | 31o\_pyramidal19aFI  | fronto-insula      | 2.26                  | 303.55             | 65950.80                | 86376.72                 |
-
-The neuron models and the measurement data are from (Ascoli 2007) and (Watson 2006).

--- a/docs/src/references.md
+++ b/docs/src/references.md
@@ -1,0 +1,4 @@
+# References
+
+```@bibliography
+```

--- a/docs/src/theory/adc.md
+++ b/docs/src/theory/adc.md
@@ -6,7 +6,7 @@ amplitude ``g > 0``, time profile ``f : [0, T_\text{echo}] \to [-1, 1]`` and dir
 
 Some commonly used time profiles (diffusion-encoding sequences) are:
 
-- The pulsed-gradient spin echo (PGSE) sequence:
+- The pulsed-gradient spin echo (PGSE) sequence [Stejskal1965](@cite):
   ```math
   f(t) =
   \begin{cases}
@@ -21,7 +21,7 @@ Some commonly used time profiles (diffusion-encoding sequences) are:
   t_\text{pause}) \right),
   ```
   where ``f_{\delta, \Delta}`` is a normal PGSE sequence;
-- The oscillating gradient spin echo (OGSE) sequence (here, cos-OGSE):
+- The oscillating gradient spin echo (OGSE) sequence (here, cos-OGSE) [Callaghan1995](@cite), [Does2003](@cite):
   ```math
   f(t) =
   \begin{cases}
@@ -46,14 +46,14 @@ b(g, f) = \gamma^2 g^2 \int_0^{T_\text{echo}} \left( \int_0^t f(s) \, \mathrm{d}
 \, \mathrm{d}t.
 ```
 
-For PGSE, the b-value is:
+For PGSE, the b-value is [Stejskal1965](@cite):
 
 ```math
 b(g, \delta, \Delta) = \gamma^2 g^2 \delta^2 \left( \Delta - \delta / 3 \right).
 ```
 
 For the cosine OGSE with _integer_ number of periods ``n`` in each of the two
-durations ``\delta``, the corresponding ``b``-value is:
+durations ``\delta``, the corresponding ``b``-value is [Xu2007](@cite):
 
 ```math
 b(g, \delta) = \gamma^2 g^2 \frac{\delta^3}{4 n^2 \pi^2} = \gamma^2 g^2
@@ -113,7 +113,7 @@ D_\text{ADC}(\vec{d}) = \vec{d}^\mathsf{T} \mathbf{D}_\text{eff} \vec{d}.
 
 ## [HADC](@id HADC)
 
-In a previous work, a PDE model for the time-dependent ADC was obtained
+In a previous work [Schiavi2016](@cite), a PDE model for the time-dependent ADC was obtained
 starting from the Bloch-Torrey equation, using homogenization techniques. In the case of
 negligible water exchange between compartments (low permeability), there is no coupling
 between the compartments, at least to the quadratic order in ``g``, which is the ADC term.
@@ -155,7 +155,7 @@ model that we call the HADC model.
 ## [Short diffusion time approximation](@id STA)
 
 A well-known formula for the ADC in the short diffusion time regime is the following short
-time approximation (STA):
+time approximation (STA) [Mitra1992](@cite), [Mitra1993](@cite):
 
 ```math
 D_\text{STA} = \left(1 - \frac{4\sqrt{D_0}}{3 \sqrt{\pi}}\sqrt{\Delta} \frac{{A}}{d\; V}
@@ -164,9 +164,9 @@ D_\text{STA} = \left(1 - \frac{4\sqrt{D_0}}{3 \sqrt{\pi}}\sqrt{\Delta} \frac{{A}
 where ``\dfrac{A}{V}`` is the surface to volume ratio, ``d`` is the spatial dimension and
 ``D_0 = \vec{d}^\mathsf{T} \mathbf{D} \vec{d}`` is the intrinsic diffusion
 coefficient in the gradient direction. In the above formula, the pulse duration ``\delta``
-is assumed to be very small compared to ``\Delta``. A recent correction to the above formula
-, taking into account the finite pulse duration ``\delta`` and the
-gradient direction ``\vec{d}``, is the following:
+is assumed to be very small compared to ``\Delta``. A recent correction to the
+above formula [Schiavi2016](@cite), taking into account the finite pulse
+duration ``\delta`` and the gradient direction ``\vec{d}``, is the following:
 
 ```math
 D_\text{STA} = \left(1 - \frac{4 \sqrt{D_0}}{3 \sqrt{\pi}} C_{\delta,\Delta}

--- a/docs/src/theory/btpde.md
+++ b/docs/src/theory/btpde.md
@@ -62,7 +62,7 @@ where
     gradient, or
   - ``c_{i j} = \frac{2 \rho_i}{\rho_i + \rho_j}`` and ``c_{j i} = \frac{2 \rho_j}{\rho_i +
     \rho_j}``, which ensures that the non-uniform intitial spin density is preserved in the
-    absence of a gradient.
+    absence of a gradient [Lee2021](@cite).
 
 The diffusion MRI signal is measured at echo time ``t = T_\text{echo}``. This signal is
 computed as the spatial integral of the final magnetization ``M(\cdot,

--- a/docs/src/theory/discretization.md
+++ b/docs/src/theory/discretization.md
@@ -1,7 +1,8 @@
 # Finite element discretization
 
 In SpinDoctor, the finite element mesh generation is performed using an external package
-called Tetgen. Each finite element mesh consists of
+called Tetgen in 3D [Si2015](@cite), and Triangle in 2D [Shewchuk1996b](@cite).
+Each finite element mesh consists of
 
 - a list of ``N_\text{node}`` nodes in three dimensions: ``(\mathbf{q}_1, \dots,
   \mathbf{q}_{N_\text{node}}) = (\mathbf{q}^x, \mathbf{q}^y, \mathbf{q}^z)^\mathsf{T} \in
@@ -134,7 +135,7 @@ R_{kl} = \int_\Omega \frac{1}{T_2(\vec{x})} \, \varphi_k(\vec{x}) \varphi_l(\vec
 ```
 
 In SpinDoctor, these matrices are assembled from local element matrices and the assembly
-process is based on vectorized routines of, which replace expensive
+process is based on vectorized routines from [Rahman2013](@cite), which replace expensive
 loops over elements by operations with 3-dimensional arrays. All local element matrices in
 the assembly of ``\mathbf{S}``, ``\mathbf{M}``, and ``\mathbf{Q}`` are evaluated at the same time and
 stored in a full matrix of size ``4 \times 4 \times N_\text{element}``, where

--- a/docs/src/theory/matrix_formalism.md
+++ b/docs/src/theory/matrix_formalism.md
@@ -1,5 +1,17 @@
 # Matrix formalism
 
+The Matrix Formalism [Callaghan1997](@cite), [Barzykin1999](@cite)
+representation of the solution to the Bloch-Torrey PDE is based on the
+generalized Laplace eigenfunctions of the given geometrical configuration. These
+are the eigenfunctions of the generalized Laplace operator $-\nabla \cdot
+\mat{D} \nabla$ subject to the same boundary and interface conditions as the
+BTPDE. It which does not depend on the gradient sequence. The Matrix Formalism
+truncates the number of Laplace eigenmodes at an acceptable level, by setting a
+minimum length scale for the eigenfunctions. The gradient sequence dependent
+Bloch-Torrey operator can then be expressed in the truncated Laplace
+eigenfunction basis. This allows for a simple analytical expression which
+approximates the solution to the BTPDE down to an arbitrary length scale.
+
 # Eigenvalue decomposition of the generalized Laplace operator
 
 Let ``\{(\phi, \lambda)\}`` be the ``L^2``-normalized eigenfunctions and eigenvalues of the
@@ -137,7 +149,8 @@ The initial coefficients are given by
 \vec{\nu}(0) = \int_\Omega \rho(\vec{x}) \vec{\phi}(\vec{x}) \, \mathrm{d} \Omega(\vec{x}).
 ```
 
-By using a piece-wise constant approximation of the gradient ``\vec{g}``, we obtain
+By using a piece-wise constant approximation of the gradient ``\vec{g}``
+[Barzykin1999](@cite), we obtain
 
 ```math
 \vec{\nu}(T_\text{echo}) \approx \left(\prod_{i = 1}^{N_\text{int}} \mathrm{e}^{-\delta_i

--- a/examples/setups/neuron.jl
+++ b/examples/setups/neuron.jl
@@ -6,6 +6,9 @@
 # in order to run SpinDoctor simulations on real neuron geometries. Since the
 # files take up a lot of space, this script automatically downloads the chosen
 # file only, and unzips it.
+#
+# See [Fang2020](@cite) for information about working with neurons in
+# SpinDoctor.
 
 using Downloads
 using ZipFile

--- a/src/analytical/solve_analytical_mf.jl
+++ b/src/analytical/solve_analytical_mf.jl
@@ -5,10 +5,8 @@ Compute the signal in a multilayered cylinder or sphere using an analytical
 matrix formalism solution.
 
 This function is based on the following articles and corresponding code:
-    [1] D. S. Grebenkov, NMR Survey of Reflected Brownian Motion,
-        Rev. Mod.Phys. 79, 1077 (2007)
-    [2] D. S. Grebenkov, Pulsed-gradient spin-echo monitoring of restricted diffusion in
-        multilayered structures, J. Magn. Reson. 205, 181-195 (2010).
+    [1] [Grebenkov2007](@cite)
+    [2] [Grebenkov2010a](@cite)
 """
 function solve(problem::AnalyticalMatrixFormalism, gradient::ScalarGradient)
     (; analytical_laplace, lap_mat, volumes) = problem

--- a/src/matrix_assembly/assemble_mass_matrix.jl
+++ b/src/matrix_assembly/assemble_mass_matrix.jl
@@ -6,10 +6,9 @@ Assemble 3D mass matrix using P1 finite elements.
 This function is based on the Matlab function `mass_matrixP1_3D.m` from the Matlab
 nodal matrix assembly toolbox by Jan Valdman and Talal Rahmnan:
 
-https://uk.mathworks.com/matlabcentral/fileexchange/27826-fast-fem-assembly-nodal-elements
+<https://uk.mathworks.com/matlabcentral/fileexchange/27826-fast-fem-assembly-nodal-elements>
 
-Talal Rahman and Jan Valdman: Fast MATLAB assembly of FEM matrices in 2D and 3D: nodal
-elements, Applied Mathematics and Computation 219, 7151–7158 (2013).
+[Rahman2013](@cite)
 """
 function assemble_mass_matrix(elements, nodes, weights = 1)
     nnode = size(nodes, 2)

--- a/src/matrix_assembly/assemble_stiffness_matrix.jl
+++ b/src/matrix_assembly/assemble_stiffness_matrix.jl
@@ -9,8 +9,7 @@ nodal matrix assembly toolbox by Jan Valdman and Talal Rahman.
 
 <https://uk.mathworks.com/matlabcentral/fileexchange/27826-fast-fem-assembly-nodal-elements>
 
-Talal Rahman and Jan Valdman: Fast MATLAB assembly of FEM matrices in 2D and 3D: nodal
-elements, Applied Mathematics and Computation 219, 7151–7158 (2013).
+[Rahman2013](@cite)
 """
 function assemble_stiffness_matrix(elements, nodes, D = I(3))
     dim, nnode = size(nodes)

--- a/src/matrix_formalism/solve_laplace.jl
+++ b/src/matrix_formalism/solve_laplace.jl
@@ -2,6 +2,8 @@
     solve(problem::Laplace)
 
 Compute the Laplace eigenvalues, eigenfunctions and first order moments of products of pairs of eigenfunctions.
+
+See [Li2020](@cite), [Agdestein2021](@cite).
 """
 function solve(laplace::Laplace{T,dim}) where {T,dim}
     (; matrices, neig_max) = laplace

--- a/src/matrix_formalism/solve_mf.jl
+++ b/src/matrix_formalism/solve_mf.jl
@@ -2,6 +2,8 @@
     solve(problem::MatrixFormalism, gradient; ninterval = 500)
 
 Solve for magnetization using Matrix Formalism.
+
+See [Li2020](@cite), [Agdestein2021](@cite).
 """
 function solve(problem::MatrixFormalism{TT,dim}, gradient; ninterval = 500) where {TT,dim}
     (; model, matrices, lap_eig) = problem


### PR DESCRIPTION
Using the package [`DocumenterCitations.jl`](https://github.com/ali-ramadhan/DocumenterCitations.jl), references can be cited anywhere in the code, comments, and docstrings:

```md
[CitationLabel](@cite)
```

The references are stored in BibTex format in the file `docs/references.bib`.

All citations in docstrings and comments in the files generated to the examples page will link to the references page.